### PR TITLE
Fix guardian url

### DIFF
--- a/_posts/2015-10-13-dprk-part-1.markdown
+++ b/_posts/2015-10-13-dprk-part-1.markdown
@@ -119,4 +119,4 @@ If you want to see some footage of the DPRK which I recorded, I've been posting 
 
 Also, Koryo Tours have plenty more DPRK information and photos if you want further glimpses into North Korean life, largely on social media: [Instagram of Vicky, my tour guide](http://instagram.com/vickyinam), [Koryo on Facebook](https://www.facebook.com/koryotours), [Koryo on Twitter](https://twitter.com/koryotours), [Koryo on Tumblr](http://koryotours.tumblr.com/). They also have a website where you can find out about their tours and humanitarian projects, [koryogroup.com](http://koryogroup.com).
 
-Finally, if you're interested in the divisive issue of the ethics of touring in North Korea, [the Guardian recently wrote an interesting piece](www.theguardian.com/travel/2015/oct/08/north-korean-tourism-ethics). Give it a read.
+Finally, if you're interested in the divisive issue of the ethics of touring in North Korea, [the Guardian recently wrote an interesting piece](http://www.theguardian.com/travel/2015/oct/08/north-korean-tourism-ethics). Give it a read.

--- a/_posts/2015-11-04-dprk-part-2.markdown
+++ b/_posts/2015-11-04-dprk-part-2.markdown
@@ -151,4 +151,4 @@ This post is part of a series. You can see [part one here](/blog/dprk-part-1), a
 
 Also, Koryo Tours have plenty more DPRK information and photos if you want further glimpses into North Korean life, largely on social media: [Instagram of Vicky, my tour guide](http://instagram.com/vickyinam), [Koryo on Facebook](https://www.facebook.com/koryotours), [Koryo on Twitter](https://twitter.com/koryotours), [Koryo on Tumblr](http://koryotours.tumblr.com/). They also have a website where you can find out about their tours and humanitarian projects, [koryogroup.com](http://koryogroup.com).
 
-Finally, if you're interested in the divisive issue of the ethics of touring in North Korea, [the Guardian recently wrote an interesting piece](www.theguardian.com/travel/2015/oct/08/north-korean-tourism-ethics). Give it a read.
+Finally, if you're interested in the divisive issue of the ethics of touring in North Korea, [the Guardian recently wrote an interesting piece](http://www.theguardian.com/travel/2015/oct/08/north-korean-tourism-ethics). Give it a read.

--- a/_posts/2015-12-04-dprk-part-3.markdown
+++ b/_posts/2015-12-04-dprk-part-3.markdown
@@ -182,4 +182,4 @@ This post is part of a series. You can see [part one here](/blog/dprk-part-1), [
 
 Also, Koryo Tours have plenty more DPRK information and photos if you want further glimpses into North Korean life, largely on social media: [Instagram of Vicky, my tour guide](http://instagram.com/vickyinam), [Koryo on Facebook](https://www.facebook.com/koryotours), [Koryo on Twitter](https://twitter.com/koryotours), [Koryo on Tumblr](http://koryotours.tumblr.com/). They also have a website where you can find out about their tours and humanitarian projects, [koryogroup.com](http://koryogroup.com).
 
-Finally, if you're interested in the divisive issue of the ethics of touring in North Korea, [the Guardian recently wrote an interesting piece](www.theguardian.com/travel/2015/oct/08/north-korean-tourism-ethics). Give it a read.
+Finally, if you're interested in the divisive issue of the ethics of touring in North Korea, [the Guardian recently wrote an interesting piece](http://www.theguardian.com/travel/2015/oct/08/north-korean-tourism-ethics). Give it a read.

--- a/_posts/2015-12-14-dprk-part-4.markdown
+++ b/_posts/2015-12-14-dprk-part-4.markdown
@@ -300,4 +300,4 @@ This post is part of a series. You can see [part one here](/blog/dprk-part-1), [
 
 Also, Koryo Tours have plenty more DPRK information and photos if you want further glimpses into North Korean life, largely on social media: [Instagram of Vicky, my tour guide](http://instagram.com/vickyinam), [Koryo on Facebook](https://www.facebook.com/koryotours), [Koryo on Twitter](https://twitter.com/koryotours), [Koryo on Tumblr](http://koryotours.tumblr.com/). They also have a website where you can find out about their tours and humanitarian projects, [koryogroup.com](http://koryogroup.com).
 
-Finally, if you're interested in the divisive issue of the ethics of touring in North Korea, [the Guardian recently wrote an interesting piece](www.theguardian.com/travel/2015/oct/08/north-korean-tourism-ethics). Give it a read.
+Finally, if you're interested in the divisive issue of the ethics of touring in North Korea, [the Guardian recently wrote an interesting piece](http://www.theguardian.com/travel/2015/oct/08/north-korean-tourism-ethics). Give it a read.


### PR DESCRIPTION
Some links to theguardian.com end up being treated as relative (missing the protocol prefix).

e.g: See link at the bottom of this [post](https://danhough.com/blog/dprk-part-1) which ends up as:
```
https://danhough.com/blog/dprk-part-1/www.theguardian.com/travel/2015/oct/08/north-korean-tourism-ethics
```
#baguette