### PR TITLE
Fix to allow Disqus comments to load over https

### DIFF
--- a/_includes/disqus.html
+++ b/_includes/disqus.html
@@ -13,7 +13,7 @@
 		    /* * * DON'T EDIT BELOW THIS LINE * * */
 		    (function() {
 		        var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-		        dsq.src = 'http://' + disqus_shortname + '.disqus.com/embed.js';
+		        dsq.src = '//' + disqus_shortname + '.disqus.com/embed.js';
 		        (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
 		    })();
 		</script>


### PR DESCRIPTION
Currently get a mixed content warning that prevents the embed from loading.
Removing `http:` on Disqus embed to allows it to load correctly over https.